### PR TITLE
Check if server before including sv_config and running the config load function

### DIFF
--- a/lua/autorun/paynow_autorun.lua
+++ b/lua/autorun/paynow_autorun.lua
@@ -54,8 +54,10 @@ end
 -- Include the actual addon files
 
 function PayNow.LoadAddon()
-    include("paynow/sv_config.lua")
-    PayNow.Config.Load()
+	if (SERVER) then
+		include("paynow/sv_config.lua")
+		PayNow.Config.Load()
+	end
     
     PayNow.Load("paynow")
 end


### PR DESCRIPTION
Due to sv_config being a serverside file and config.load being inside sv_config.lua, it causes an error on the client when they load. This change ensures that include sv_config, and the config load function are only called if it is being run on the server. While still allowing for shared and clientside files to still be added in the future if needed.

```
[paynow] Couldn't include file 'paynow\sv_config.lua' - File not found or is empty (@addons/paynow/lua/autorun/paynow_autorun.lua (line 57))
    1. LoadAddon - addons/paynow/lua/autorun/paynow_autorun.lua:57
    2. unknown - addons/paynow/lua/autorun/paynow_autorun.lua:63

[paynow] addons/paynow/lua/autorun/paynow_autorun.lua:58: attempt to index field 'Config' (a nil value)    
  1. LoadAddon - addons/paynow/lua/autorun/paynow_autorun.lua:58
  2. unknown - addons/paynow/lua/autorun/paynow_autorun.lua:63
```